### PR TITLE
fix: fix non-default plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "xo": "^0.58.0"
       },
       "engines": {
-        "vscode": "^1.90.0"
+        "vscode": "^1.82.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -294,9 +294,9 @@
   "xo": {
     "space": 2,
     "rules": {
-			"@typescript-eslint/prefer-nullish-coalescing": "off",
+      "@typescript-eslint/prefer-nullish-coalescing": "off",
       "@typescript-eslint/no-empty-function": "off"
-		}
+    }
   },
   "dependencies": {
     "lodash.merge": "^4.6.2",

--- a/package.json
+++ b/package.json
@@ -291,12 +291,12 @@
       ]
     }
   },
-  "activationEvents": [
-    "onCommand:svgo.minify",
-    "onCommand:svgo.format"
-  ],
   "xo": {
-    "space": 2
+    "space": 2,
+    "rules": {
+			"@typescript-eslint/prefer-nullish-coalescing": "off",
+      "@typescript-eslint/no-empty-function": "off"
+		}
   },
   "dependencies": {
     "lodash.merge": "^4.6.2",
@@ -310,7 +310,7 @@
     "xo": "^0.58.0"
   },
   "engines": {
-    "vscode": "^1.90.0"
+    "vscode": "^1.82.0"
   },
   "icon": "img/icon.png"
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,19 @@ import {
   type PluginConfig,
 } from 'svgo';
 
+/** Name of all plugins that are enabled/invoked by default. */
+const defaultPlugins = new Set(
+  builtinPlugins
+    .find(p => p.name === 'preset-default')
+    .plugins
+    .map(p => p.name),
+);
+
+/** Name of all builtin plugins, excluding presets. */
+const builtin = builtinPlugins
+  .filter(p => !p.isPreset)
+  .map(p => p.name);
+
 function isSvg({languageId, fileName}: TextDocument): boolean {
   return languageId === 'xml' && fileName.endsWith('.svg');
 }
@@ -34,17 +47,22 @@ function getPluginConfig(): Config {
       overrides: {},
     },
   };
+  const otherPlugins: PluginConfig[] = [];
 
-  for (const plugin of builtinPlugins) {
+  for (const plugin of builtin) {
     // If plugin is configured by workspace config
-    if (!svgoConfig.has(plugin.name)) {
+    if (!svgoConfig.has(plugin)) {
       continue;
     }
 
-    defaultPlugin.params.overrides[plugin.name] = svgoConfig.get<boolean>(plugin.name);
+    if (defaultPlugins.has(plugin)) {
+      defaultPlugin.params.overrides[plugin] = svgoConfig.get<boolean>(plugin);
+    } else if (svgoConfig.get<boolean>(plugin)) {
+      otherPlugins.push(plugin as PluginConfig);
+    }
   }
 
-  const plugins: PluginConfig[] = [defaultPlugin];
+  const plugins: PluginConfig[] = [defaultPlugin, ...otherPlugins];
   const pluginConfig: Config = {plugins};
 
   return pluginConfig;
@@ -143,5 +161,4 @@ export function activate(context: ExtensionContext) {
   );
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
 export function deactivate() {}


### PR DESCRIPTION
Fixes an issue that would've existed since the project was using SVGO v2.0.0. The `preset-default` `override` parameter is only used to disable plugins that are a part of `preset-default`, but it can not enable plugins that aren't.

This puts plugins that are not in `preset-default` as new items in the plugin array instead of in the `override` parameter. Now they actually get invoked.

### Chores

I've also done some chores, feel free to ask me to revert any of them or ask for clarification if needed:

* In `package.json`, the `engines.vscode` reflects the minimum version of VSC your extension supports. By increasing it, you stop people from being able to install or use this add-on who are on older versions. Ideally, you want this as low as possible, only increasing it when you actually use a new feature only available in higher versions.
  * Even I'm still on version 1.89 atm, so I actually had to lower it to make this contribution. You can probably lower it down to `^1.14.0`, or even lower, but I figured just reverting it to the previous commit is safest for now.
* I disabled `@typescript-eslint/prefer-nullish-coalescing` which allows CI to pass again. I intentionally opted for this instead of applying the fix, because it wanted to make the code overly defensive and put null checks in place where the properly obviously couldn't be null.
* I also moved `@typescript-eslint/no-empty-function` into your `package.json`.

> `engines.vscode`: This specifies the minimum version of VS Code API that the extension depends on.
> 
> — https://code.visualstudio.com/api/get-started/extension-anatomy

### Screenshots

#### Before

Observe that despite having [removeXMLNS](https://svgo.dev/docs/plugins/removeXMLNS/) enabled, the XML namespace declaration is still there.

![xmlns-not-removed](https://github.com/1000ch/vscode-svgo/assets/22801583/d49c40b8-b47a-45d3-8fb7-dfa505b76c6a)

#### After

Observe that the XML namespace declaration is now gone.

![image](https://github.com/1000ch/vscode-svgo/assets/22801583/efddba6c-8c49-4d0c-87bd-bc3b95fad9f8)
