### PR TITLE
deps: upgrade svgo to v4.0.0 stable (plus a bunch of other fixes)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "lodash.merge": "^4.6.2",
-        "svgo": "^4.0.0-rc.4"
+        "svgo": "^4.0.0"
       },
       "devDependencies": {
         "@types/lodash.merge": "^4.6.9",
@@ -110,9 +110,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -173,9 +173,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -871,9 +871,9 @@
       "peer": true
     },
     "node_modules/acorn": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1179,9 +1179,9 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2164,18 +2164,13 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "10.1.5",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.5.tgz",
-      "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
+      "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint-config-prettier"
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
@@ -2242,10 +2237,11 @@
       }
     },
     "node_modules/eslint-formatter-pretty/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -2498,9 +2494,9 @@
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2608,9 +2604,9 @@
       }
     },
     "node_modules/eslint-plugin-n/node_modules/tapable": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
+      "integrity": "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2803,9 +2799,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2871,15 +2867,15 @@
       }
     },
     "node_modules/espree": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
-      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.14.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.0"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2889,9 +2885,9 @@
       }
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -3234,10 +3230,11 @@
       }
     },
     "node_modules/find-cache-dir/node_modules/yocto-queue": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
-      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12.20"
       },
@@ -3532,9 +3529,9 @@
       "peer": true
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3610,9 +3607,9 @@
       }
     },
     "node_modules/globby/node_modules/ignore": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.4.tgz",
-      "integrity": "sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4736,10 +4733,11 @@
       }
     },
     "node_modules/log-symbols/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -6224,10 +6222,11 @@
       }
     },
     "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -6410,9 +6409,9 @@
       }
     },
     "node_modules/svgo": {
-      "version": "4.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.0-rc.4.tgz",
-      "integrity": "sha512-Fjyz8GjLVpj0G9IaJKugutEL1dX8GIlotz2d4C1Ug6x4oqd4d4QIp04e/M5fZalJ0gvVQDAcaMEdfzkfAoLtXA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.0.tgz",
+      "integrity": "sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw==",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",
@@ -6949,9 +6948,9 @@
       }
     },
     "node_modules/webpack/node_modules/tapable": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
+      "integrity": "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -7125,19 +7124,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/xo/node_modules/eslint-config-prettier": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
-      "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "eslint-config-prettier": "bin/cli.js"
-      },
-      "peerDependencies": {
-        "eslint": ">=7.0.0"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -7221,9 +7207,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "version": "1.1.12",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+          "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -7265,9 +7251,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "version": "1.1.12",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+          "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -7778,9 +7764,9 @@
       "peer": true
     },
     "acorn": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true
     },
     "acorn-jsx": {
@@ -7978,9 +7964,9 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
     },
     "brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0"
@@ -8632,9 +8618,9 @@
           }
         },
         "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "version": "1.1.12",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+          "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -8682,12 +8668,10 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "10.1.5",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.5.tgz",
-      "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
+      "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "requires": {}
     },
     "eslint-config-xo": {
@@ -8723,9 +8707,9 @@
       },
       "dependencies": {
         "chalk": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-          "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+          "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
           "dev": true
         }
       }
@@ -8904,9 +8888,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "version": "1.1.12",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+          "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -8981,9 +8965,9 @@
           "dev": true
         },
         "tapable": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-          "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
+          "integrity": "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==",
           "dev": true
         }
       }
@@ -9091,20 +9075,20 @@
       }
     },
     "espree": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
-      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "requires": {
-        "acorn": "^8.14.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.0"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "dependencies": {
         "eslint-visitor-keys": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-          "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+          "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
           "dev": true
         }
       }
@@ -9331,9 +9315,9 @@
           }
         },
         "yocto-queue": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
-          "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+          "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
           "dev": true
         }
       }
@@ -9509,9 +9493,9 @@
       },
       "dependencies": {
         "brace-expansion": {
-          "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "version": "1.1.12",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+          "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
@@ -9579,9 +9563,9 @@
       },
       "dependencies": {
         "ignore": {
-          "version": "7.0.4",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.4.tgz",
-          "integrity": "sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A==",
+          "version": "7.0.5",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+          "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
           "dev": true
         }
       }
@@ -10300,9 +10284,9 @@
       },
       "dependencies": {
         "chalk": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-          "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+          "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
           "dev": true
         }
       }
@@ -11267,9 +11251,9 @@
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+          "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
           "dev": true
         },
         "strip-ansi": {
@@ -11383,9 +11367,9 @@
       "dev": true
     },
     "svgo": {
-      "version": "4.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.0-rc.4.tgz",
-      "integrity": "sha512-Fjyz8GjLVpj0G9IaJKugutEL1dX8GIlotz2d4C1Ug6x4oqd4d4QIp04e/M5fZalJ0gvVQDAcaMEdfzkfAoLtXA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.0.tgz",
+      "integrity": "sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw==",
       "requires": {
         "commander": "^11.1.0",
         "css-select": "^5.1.0",
@@ -11721,9 +11705,9 @@
           "peer": true
         },
         "tapable": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-          "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
+          "integrity": "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==",
           "dev": true,
           "peer": true
         }
@@ -11855,15 +11839,6 @@
         "slash": "^5.1.0",
         "to-absolute-glob": "^3.0.0",
         "typescript": "^5.5.3"
-      },
-      "dependencies": {
-        "eslint-config-prettier": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
-          "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
-          "dev": true,
-          "requires": {}
-        }
       }
     },
     "yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -55,11 +55,11 @@
         "svgo.cleanupIds": {
           "type": "boolean",
           "default": true,
-          "description": "emoves unused IDs, and minifys IDs that are referenced by other elements."
+          "description": "Removes unused IDs, and minifies IDs that are referenced by other elements."
         },
         "svgo.cleanupListOfValues": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "Rounds numeric values in attributes, such as those found in viewBox, enable-background, and points."
         },
         "svgo.cleanupNumericValues": {
@@ -212,7 +212,7 @@
           "default": false,
           "description": "Removes inline JPEGs, PNGs, and GIFs from the document."
         },
-        "svgo.removeScriptElement": {
+        "svgo.removeScripts": {
           "type": "boolean",
           "default": false,
           "description": "Removes all scripts from the document. SVGs can be interactive through JavaScript. However, unless the SVG is coming from a trusted source, it's strongly advised to strip off JavaScript to avoid XSS attacks."
@@ -224,7 +224,7 @@
         },
         "svgo.removeTitle": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "Removes the <title> element from the document. This plugin may have significant accessibility implications. The purpose of <title> is to provide users of assistive technologies the means to get a summary of the SVG if they're not able to view it."
         },
         "svgo.removeUnknownsAndDefaults": {
@@ -249,7 +249,7 @@
         },
         "svgo.removeViewBox": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "Removes the viewBox attribute where it matches the documents width and height."
         },
         "svgo.removeXMLNS": {
@@ -264,7 +264,7 @@
         },
         "svgo.removeXlink": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "Removes XLink namespace prefixes and converts references to XLink attributes to the native SVG equivalent."
         },
         "svgo.reusePaths": {

--- a/package.json
+++ b/package.json
@@ -42,16 +42,6 @@
       "type": "object",
       "title": "SVGO",
       "properties": {
-        "svgo.addClassesToSVGElement": {
-          "type": "boolean",
-          "default": false,
-          "description": "Overrides the class attribute in the outer most <svg> element, omitting duplicates or null classes if found in your configuration."
-        },
-        "svgo.addAttributesToSVGElement": {
-          "type": "boolean",
-          "default": false,
-          "description": "Adds attributes to the outer most <svg> element in the document. This is not an optimization and will increase the size of SVG documents."
-        },
         "svgo.cleanupAttrs": {
           "type": "boolean",
           "default": true,
@@ -152,16 +142,6 @@
           "default": false,
           "description": "Prefix element IDs and class names with the filename or another arbitrary string. This is useful for reducing the likeliness of ID conflicts when multiple vectors are inlined into the same document."
         },
-        "svgo.removeAttributesBySelector": {
-          "type": "boolean",
-          "default": false,
-          "description": "Removes specific attributes from elements that match a CSS selector."
-        },
-        "svgo.removeAttrs": {
-          "type": "boolean",
-          "default": false,
-          "description": "Remove attributes from elements matching a custom syntax."
-        },
         "svgo.removeComments": {
           "type": "boolean",
           "default": true,
@@ -191,11 +171,6 @@
           "type": "boolean",
           "default": true,
           "description": "Removes all XML namespaces, elements, and attributes associated with popular vector editing software. This plugin is completely safe to use before redistributing your SVG or incorporating it into a larger document."
-        },
-        "svgo.removeElementsByAttr": {
-          "type": "boolean",
-          "default": false,
-          "description": "Removes arbitrary elements by ID or className."
         },
         "svgo.removeEmptyAttrs": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -308,7 +308,7 @@
   },
   "dependencies": {
     "lodash.merge": "^4.6.2",
-    "svgo": "^4.0.0-rc.4"
+    "svgo": "^4.0.0"
   },
   "devDependencies": {
     "@types/lodash.merge": "^4.6.9",

--- a/package.json
+++ b/package.json
@@ -342,7 +342,7 @@
     "xo": "^0.59.3"
   },
   "engines": {
-    "vscode": "^1.100.0"
+    "vscode": "^1.98.0"
   },
   "icon": "img/icon.png"
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -98,14 +98,14 @@ async function getConfig(config: Config): Promise<Config> {
   return merge(pluginConfig, projectConfig, config);
 }
 
-async function processTextEditor(textEditor: TextEditor, config?: Config) {
+async function processTextEditor(textEditor: TextEditor, config?: Config, cascdeConfig = true) {
   if (!isSvg(textEditor.document)) {
     return;
   }
 
-  const mergedConfig = await getConfig(config);
+  const finalConfig = cascdeConfig ? await getConfig(config) : config;
   const text = textEditor.document.getText();
-  const {data} = optimize(text, mergedConfig);
+  const {data} = optimize(text, finalConfig);
   await setText(data, textEditor);
 }
 
@@ -138,13 +138,14 @@ async function format() {
   }
 
   const config: Config = {
+    plugins: [],
     js2svg: {
       pretty: true,
     },
   };
 
   try {
-    await processTextEditor(window.activeTextEditor, config);
+    await processTextEditor(window.activeTextEditor, config, false);
     await window.showInformationMessage('Prettified current SVG file');
   } catch (error: unknown) {
     console.error(error);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -98,12 +98,12 @@ async function getConfig(config: Config): Promise<Config> {
   return merge(pluginConfig, projectConfig, config);
 }
 
-async function processTextEditor(textEditor: TextEditor, config?: Config, cascdeConfig = true) {
+async function processTextEditor(textEditor: TextEditor, config?: Config, cascadeConfig = true) {
   if (!isSvg(textEditor.document)) {
     return;
   }
 
-  const finalConfig = cascdeConfig ? await getConfig(config) : config;
+  const finalConfig = cascadeConfig ? await getConfig(config) : config;
   const text = textEditor.document.getText();
   const {data} = optimize(text, finalConfig);
   await setText(data, textEditor);


### PR DESCRIPTION
My primary goal here was to upgrade from the svgo@rc to svgo@4.0.0, but I encountered a few other issues. I figured I could propose them at once, and you can let me know if you disagree.

I'll explain each commit in order.

### chore: lower engines.vscode

I wrote about this in my last PR here! `engines.vscode` should only be incremented as the minimum required version to use your extension changes. By increasing this value eagerly, people who are perfectly able to use your extension won't be able to, as VSC disables the plugin and blocks it from loading.

For example, I was unable to contribute to your extension until I reduced this, because I only have VSC v1.98.0 installed, not v1.100.0. But your extension worked perfectly fine on v1.98.0. :sob:

### fix: remove plugins with required parameters from vsc config

As far as your VSC configuration goes, only `true`/`false` is supported. We have a few plugins that _require_ parameters, it makes no sense to include them in the VSC config as turning these on could only break the extension, at least with the current paradigm.

I propose that the ones with a required config should be removed, and they can only be configured via a workspace `svgo.config.js` file.

The affected plugins are:

* `addClassesToSVGElement`
* `addAttributesToSVGElement`
* `removeAttributesBySelector`
* `removeAttrs`
* `removeElementsByAttr`

In future, if you support JSON in the VSC config too, you could bring these back.

#### @ts-expect-error

This in turn also fixes the obscure type error that you had a TS ignore comment on.

The problem is that plugins with required parameters can not be enabled using just the name of the plugin. They can only be enabled via object notation. So the types indeed do not match.

This solves the issue by removing plugins with required parameters, and coercing the type to `BuiltinsWithOptionalParams`, which represents the list of plugins that do not require parameters. (And therefore can be enabled from the string alone.)

### fix: formatting should not minify svgs

Your formatting command was also optimizing the SVG with formatting. It was not just formatting the SVG!

This is solved by specifying an empty array of plugins, and adding a `cascadeConfig` option, so the caller can control if they want the config passed to cascade with the workspace and VSC config or not. In the case of formatting, we don't because it's only formatting.

### deps: upgrade svgo to v4.0.0 stable

Simply upgrades from SVGO v4.0.0-rc.4 to SVGO v4.0.0. :tada: 

### chore: update config to match closer to svgo defaults

* Updates a description as you missed the first character when copying it.
* Renames `removeScriptElement` to `removeScripts`, which is the new name.
* Disables `removeViewBox` and `removeTitle` as these have been disabled by default, and is strongly discouraged.
* Update a few other config items to closer match SVGO defaults.

---

Feel free to disagree with any individual commit! You can either cherry-pick them, or ask me to drop it from my branch.